### PR TITLE
Added GitHub token permissions to chart-release-checks.yml

### DIFF
--- a/.github/workflows/chart-release-checks.yml
+++ b/.github/workflows/chart-release-checks.yml
@@ -39,6 +39,10 @@ jobs:
     name: Checks
     runs-on: ubuntu-20.04
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Download Shared Workflow Properties
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Missing GitHub token permissions are now present in `chart-release-checks.yml`.