### PR TITLE
Looser YAML lint rules for slate-deployment.yml

### DIFF
--- a/.github/workflows/slate-deployment.yml
+++ b/.github/workflows/slate-deployment.yml
@@ -65,7 +65,11 @@ jobs:
           config_data: |
             extends: default
             rules:
+              empty-lines:
+                level: warning
               line-length:
+                level: warning
+              new-line-at-end-of-file:
                 level: warning
           file_or_dir: ./*/values.yaml ./*/instance.yaml
 

--- a/scripts/semver-health.py
+++ b/scripts/semver-health.py
@@ -70,4 +70,4 @@ if __name__ == '__main__':
             f" of the deployed appVersion \"{deployed_appversion}\". Update the source and" +
             " try again."
         )
-    logging.info("Source appVersion is correctly head of deployed appVersion.")
+    logging.info("Source appVersion is correctly ahead of deployed appVersion.")


### PR DESCRIPTION
* `empty-lines` and `new-line-at-end-of-file` are now just warnings.