### PR TITLE
trailing spaces now a warning, down from error.

### DIFF
--- a/.github/workflows/slate-deployment.yml
+++ b/.github/workflows/slate-deployment.yml
@@ -71,6 +71,8 @@ jobs:
                 level: warning
               new-line-at-end-of-file:
                 level: warning
+              trailing-spaces:
+                level: warning
           file_or_dir: ./*/values.yaml ./*/instance.yaml
 
   deploy:


### PR DESCRIPTION
See #21 for more details.