### PR TITLE
trailing spaces now a warning, down from error. (#22)

### DIFF
--- a/.github/workflows/slate-deployment.yml
+++ b/.github/workflows/slate-deployment.yml
@@ -71,6 +71,8 @@ jobs:
                 level: warning
               new-line-at-end-of-file:
                 level: warning
+              trailing-spaces:
+                level: warning
           file_or_dir: ./*/values.yaml ./*/instance.yaml
 
   deploy:


### PR DESCRIPTION
Downgrading YAML lint rule `trailing-spaces` from error to warning.

Adding @LincolnBryant as a watcher.