### PR TITLE
Exit on error instead of trying to continue

### DIFF
--- a/.github/workflows/chart-bump-appversion.yml
+++ b/.github/workflows/chart-bump-appversion.yml
@@ -42,7 +42,7 @@ on:
 
 env:
   PRERELEASE_DATETIME_SUFFIX: "%Y%m%d-%H%M%S"
-  SLATE_GITHUB_ACTIONS_BRANCHORTAG: v5
+  SLATE_GITHUB_ACTIONS_BRANCHORTAG: v6
   SLATE_GITHUB_ACTIONS_RAWCONTENT_URL: https://raw.githubusercontent.com/slateci/github-actions
 
 jobs:

--- a/.github/workflows/chart-release-checks.yml
+++ b/.github/workflows/chart-release-checks.yml
@@ -36,7 +36,7 @@ on:
         required: true
 
 env:
-  SLATE_GITHUB_ACTIONS_BRANCHORTAG: v5
+  SLATE_GITHUB_ACTIONS_BRANCHORTAG: v6
   SLATE_GITHUB_ACTIONS_RAWCONTENT_URL: https://raw.githubusercontent.com/slateci/github-actions
 
 jobs:

--- a/.github/workflows/slate-deployment.yml
+++ b/.github/workflows/slate-deployment.yml
@@ -44,7 +44,7 @@ on:
         required: true
 
 env:
-  SLATE_GITHUB_ACTIONS_BRANCHORTAG: v5
+  SLATE_GITHUB_ACTIONS_BRANCHORTAG: v6
   SLATE_GITHUB_ACTIONS_RAWCONTENT_URL: https://raw.githubusercontent.com/slateci/github-actions
 
 jobs:

--- a/scripts/slate-instance-push-updates.py
+++ b/scripts/slate-instance-push-updates.py
@@ -27,7 +27,7 @@ else:
 
 def get_instance_id(cluster: str, app: str, retries: int = None) -> Optional[str]:
     """
-    Try to get instance id fo0r a service started at a given slate site
+    Try to get instance id for a service started at a given slate site
 
     :param app: application name to query
     :param cluster: slate cluster to query
@@ -225,13 +225,14 @@ for Entry in ChangedFiles:
         else:
             logging.error("Encountered error while adding instance")
             logging.error(f"Got a {response.status_code} from the server")
-            logging.error("Processing next entry")
-            continue
+            logging.error("Exiting with error")
+            sys.exit(1)
     # Create a new instance
     elif FileStatus == "A":
         if not add_instance():
             logging.error("Got error while adding new instance, processing next entry")
-            continue
+            logging.error("Exiting with error")
+            sys.exit(1)
     # Remove an instance
     elif FileStatus == "D":
         logging.warning("Deletion is not implemented. Your instance is still running in SLATE despite file deletion.")


### PR DESCRIPTION
Turns out I didn't need to change the workflow, just change the script so that it would fail on error instead of continuing to process the entry