### PR TITLE
Updated Linux client build to use latest base image.

### DIFF
--- a/.github/workflows/slate-client-release.yml
+++ b/.github/workflows/slate-client-release.yml
@@ -21,7 +21,7 @@ jobs:
   build-linux:
     name: Build Linux Client
     runs-on: ubuntu-20.04
-    container: hub.opensciencegrid.org/slate/slate-client-alpine:1.1.0
+    container: hub.opensciencegrid.org/slate/slate-client-alpine:1.2.0
 
     steps:
       - name: Download Shared Workflow Properties


### PR DESCRIPTION
Updated Linux client build to use `slate-client-alpine:1.2.0` in `slate-client-release.yml` github workflow.